### PR TITLE
Fallback to English locale if current locale is not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use bzmenu::{app::App, icons::Icons, launcher::LauncherType, menu::Menu};
 use clap::{builder::EnumValueParser, Arg, Command};
-use rust_i18n::{i18n, set_locale};
+use rust_i18n::{i18n, set_locale, available_locales};
 use std::{env, sync::Arc};
 use sys_locale::get_locale;
 use tokio::sync::mpsc::unbounded_channel;
@@ -14,7 +14,11 @@ async fn main() -> Result<()> {
         eprintln!("Locale not detected, defaulting to 'en-US'.");
         String::from("en-US")
     });
-    set_locale(&locale);
+    if available_locales!().iter().find(|&&x| x == &locale).is_some() {
+        set_locale(&locale);
+    } else {
+        set_locale("en");
+    }
 
     let matches = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))


### PR DESCRIPTION
I was going to add my locale translations but I don't care if English text is shown instead. Showing English when locale is not available I think it could be a better UX for users who don't have the locale.

EDIT: I was going to attach a screenshot but somehow the compiled debug app closes when I press the screenshot button.