### PR TITLE
Add Gentoo Linux installation section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Install from AUR with your favorite helper:
 paru -S bzmenu # or bzmenu-git
 ```
 
+### Gentoo Linux
+
+Install from GURU repository:
+
+```shell
+eselect repository enable guru
+emaint sync -r guru
+emerge --ask net-wireless/bzmenu
+```
+
 ## Usage
 
 ### Supported launchers


### PR DESCRIPTION
Hi! I've added bzmenu to the Gentoo [GURU](https://wiki.gentoo.org/wiki/Project:GURU) repository ([commit 33201a44](https://github.com/gentoo/guru/commit/33201a44d5ec2f667c5fcabfe89888b2877d4439)), and this PR adds the relevant documentation for Gentoo users.